### PR TITLE
adiciona uma melhor abordagem para deploy local, servidor e push para o docker registry

### DIFF
--- a/.github/workflows/docker-image-merge.yml
+++ b/.github/workflows/docker-image-merge.yml
@@ -1,0 +1,27 @@
+name: Docker Image CI
+
+on:
+  push:
+    branches: ["main"]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: checkout
+        uses: actions/checkout@v3
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v1
+
+      - name: Build the Docker image
+        run: ./run build-push

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,18 +1,14 @@
 name: Docker Image CI
 
 on:
-  push:
-    branches: [ "main" ]
   pull_request:
-    branches: [ "main" ]
+    branches: ["main"]
 
 jobs:
-
   build:
-
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
-    - name: Build the Docker image
-      run: docker build . --file Dockerfile --tag my-image-name:$(date +%s)
+      - uses: actions/checkout@v3
+      - name: Build the Docker image
+        run: docker build . --file Dockerfile --tag my-image-name:$(date +%s)

--- a/docker-compose-vm.yml
+++ b/docker-compose-vm.yml
@@ -1,0 +1,28 @@
+services:
+  app:
+    image: ${CONTAINER_IMAGE}
+    container_name: linkedIn_Backend
+    restart: always
+    networks:
+      - traefik
+      - database
+    env_file:
+      - .env
+    environment:
+      - TYPEORM_HOST=database_soujunior
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.vagas-backend.rule=Host(`vagas-backend.soujunior.tech`)"
+      - "traefik.http.routers.vagas-backend.entrypoints=websecure"
+      - "traefik.http.routers.vagas-backend.tls.certresolver=myresolver"
+      - "traefik.http.services.vagas-backend.loadbalancer.server.port=3000"
+      - "traefik.http.middlewares.traefik-headers.headers.sslredirect=true"
+      - "traefik.http.middlewares.traefik-headers.headers.sslforcehost=true"
+      - "traefik.http.middlewares.traefik-headers.headers.sslproxyheaders.X-Forwarded-Proto=https"
+      - "traefik.docker.network=traefik"
+
+networks:
+  database:
+    external: true
+  traefik:
+    external: true

--- a/run
+++ b/run
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+COMMAND=${1:-"local"}
+
+DOCKER_REPOSITORY="public.ecr.aws/a8g4m8m1/vagas-backend"
+BUILD_DOCKER_TAG=$(git log -n 1 --pretty='format:%cd-%h' --date=format:'%Y%m%d%H%M')
+
+push() {
+  docker buildx build --platform linux/arm64/v8,linux/amd64 -f Dockerfile \
+    --push -t $DOCKER_REPOSITORY:$BUILD_DOCKER_TAG .
+}
+
+compose_up() {
+  [[ ! $COMMAND == "server" ]] || declare -a args=('-f' 'docker-compose-vm.yml')
+  CONTAINER_IMAGE="$DOCKER_REPOSITORY:$BUILD_DOCKER_TAG" docker-compose ${args[*]} up -d
+}
+
+case $COMMAND in
+  build-push)
+    push;;
+  local)
+    compose_up;;
+  server)
+    compose_up;;
+esac


### PR DESCRIPTION
quando estiver rodando local:
```sh
./run
```

Para rodar no servidor:
```sh
./run server
``` 

Para o CI (precisa da autenticação da aws, e que será executado pelo runner do GitHub):
```sh
./run build-push
```

